### PR TITLE
Pacify linters, suppress noisy messages during build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,17 +12,16 @@ on:
         default: ''
         type: string
 
-permissions:
-  contents: write
-
 jobs:
   check-tag:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       tag: ${{ steps.get_tag.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
       should_build: ${{ steps.check_release.outputs.should_build }}
-    
+
     steps:
       - name: Get latest valid version tag
         id: get_tag
@@ -32,10 +31,10 @@ jobs:
             grep '"name":' | \
             grep -o '"v[0-9][^"]*"' | \
             tr -d '"')
-          
-          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+
+          if [[ -n "${INPUTS_TAG}" ]]; then
             # For manual tag input, check if it exists
-            TAG="${{ github.event.inputs.tag }}"
+            TAG="${INPUTS_TAG}"
             if echo "$UPSTREAM_TAGS" | grep -q "^${TAG}$"; then
               echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
             else
@@ -49,38 +48,42 @@ jobs:
             LATEST_TAG=$(echo "$UPSTREAM_TAGS" | sort -V | tail -n1)
             echo "tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
           fi
-          
+
           # Debug output
           echo "Available tags:"
           echo "$UPSTREAM_TAGS"
-          echo "Selected tag: $(cat $GITHUB_OUTPUT)"
+          echo "Selected tag: $(cat "$GITHUB_OUTPUT")"
+        env:
+          INPUTS_TAG: ${{ steps.get_tag.outputs.tag }}
 
       - name: Set version
         id: version
         run: |
-          TAG=${{ steps.get_tag.outputs.tag }}
-          echo "version=${TAG#v}" >> $GITHUB_OUTPUT
-          echo "Version set to: $(cat $GITHUB_OUTPUT)"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "Version set to: $(cat "$GITHUB_OUTPUT")"
+        env:
+          TAG: ${{ steps.get_tag.outputs.tag }}
 
       - name: Check if build needed
         id: check_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUTS_TAG: ${{ steps.get_tag.outputs.tag }}
+          TAG: ${{ steps.get_tag.outputs.tag }}
         run: |
-          TAG=${{ steps.get_tag.outputs.tag }}
           echo "Checking if build needed for tag: $TAG"
-          
+
           # Get all releases from this repository
           RELEASES=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/$GITHUB_REPOSITORY/releases")
-          
+
           # Check if we have a release for this tag
           TAG_RELEASE=$(echo "$RELEASES" | jq -r ".[] | select(.tag_name==\"$TAG\")")
-          
+
           # Debug output
           echo "Checking for existing release with tag: $TAG"
-          
-          if [[ -n "${{ github.event.inputs.tag }}" ]]; then
+
+          if [[ -n "${INPUTS_TAG}" ]]; then
             echo "Manual build requested, will build regardless"
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           elif [[ -z "$TAG_RELEASE" ]]; then
@@ -90,13 +93,15 @@ jobs:
             echo "Release already exists for tag $TAG, skipping build"
             echo "should_build=false" >> "$GITHUB_OUTPUT"
           fi
-          
-          echo "Final decision: $(cat $GITHUB_OUTPUT)"
+
+          echo "Final decision: $(cat "$GITHUB_OUTPUT")"
 
   build-and-package:
     needs: check-tag
     if: needs.check-tag.outputs.should_build == 'true'
     runs-on: ${{ matrix.ubuntu }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         ubuntu: [ubuntu-22.04, ubuntu-24.04]
@@ -105,6 +110,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install system dependencies
         run: |
@@ -115,19 +122,20 @@ jobs:
 
       - name: Get tagged source code
         run: |
-          TAG=${{ needs.check-tag.outputs.tag }}
           echo "Downloading source code for tag: $TAG"
-          wget "https://github.com/ghostty-org/ghostty/archive/refs/tags/${TAG}.tar.gz"
+          wget --quiet "https://github.com/ghostty-org/ghostty/archive/refs/tags/${TAG}.tar.gz"
           tar xzf "${TAG}.tar.gz"
           mv "ghostty-${TAG#v}" ghostty
           echo "Source code extracted successfully"
           ls -la ghostty/
+        env:
+          TAG: ${{ needs.check-tag.outputs.tag }}
 
       - name: Download and extract Zig
         run: |
           echo "Downloading Zig compiler..."
-          wget https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
-          tar xvf zig-linux-x86_64-0.13.0.tar.xz
+          wget --quiet https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz
+          tar xf zig-linux-x86_64-0.13.0.tar.xz
           echo "Zig compiler extracted successfully"
           ls -la zig-linux-x86_64-0.13.0/
 
@@ -137,30 +145,29 @@ jobs:
           echo "Building Ghostty with ReleaseFast optimization..."
           ../zig-linux-x86_64-0.13.0/zig build -Doptimize=ReleaseFast
           ../zig-linux-x86_64-0.13.0/zig build -Doptimize=ReleaseFast install -p ../install-root
-          
+
           echo "Checking installed files:"
           find ../install-root -type f
 
       - name: Create Debian package structure
         run: |
-          VERSION="${{ needs.check-tag.outputs.version }}"
           UBUNTU_VERSION="${{ matrix.ubuntu }}"
           UBUNTU_VERSION="${UBUNTU_VERSION#ubuntu-}"
-          
+
           echo "Creating package structure for Ubuntu $UBUNTU_VERSION"
-          
+
           mkdir -p debian-package/DEBIAN
           mkdir -p debian-package/usr/bin
           mkdir -p debian-package/usr/share
-          
+
           # Copy binary and application files
           cp -r install-root/bin/* debian-package/usr/bin/
           cp -r install-root/share/* debian-package/usr/share/
-          
+
           # Set correct permissions
           chmod 755 debian-package/usr/bin/ghostty
           chmod 644 debian-package/usr/share/applications/com.mitchellh.ghostty.desktop
-          
+
           # Create control file
           cat > debian-package/DEBIAN/control << EOF
           Package: ghostty
@@ -174,39 +181,42 @@ jobs:
            Ghostty is a fast, feature-rich, and cross-platform terminal emulator
            that uses platform-native UI and GPU acceleration.
           EOF
-          
+
           echo "Package structure created. Contents:"
           find debian-package -type f
+        env:
+          VERSION: ${{ needs.check-tag.outputs.version }}
 
       - name: Build DEB package
         run: |
-          VERSION="${{ needs.check-tag.outputs.version }}"
           UBUNTU_VERSION="${{ matrix.ubuntu }}"
           UBUNTU_VERSION="${UBUNTU_VERSION#ubuntu-}"
-          
+
           echo "Building .deb package for Ubuntu $UBUNTU_VERSION"
           dpkg-deb --build debian-package
-          
+
           # Rename package with Ubuntu version
           echo "Renaming package to include Ubuntu version"
           mv debian-package.deb "ghostty_${VERSION}_ubuntu${UBUNTU_VERSION}_amd64.deb"
-          
+
           echo "Checking final .deb file:"
           ls -l "ghostty_${VERSION}_ubuntu${UBUNTU_VERSION}_amd64.deb"
           dpkg -c "ghostty_${VERSION}_ubuntu${UBUNTU_VERSION}_amd64.deb"
+        env:
+          VERSION: ${{ needs.check-tag.outputs.version }}
 
       - name: Package binary
         run: |
           UBUNTU_VERSION="${{ matrix.ubuntu }}"
           UBUNTU_VERSION="${UBUNTU_VERSION#ubuntu-}"
-          
+
           echo "Creating portable binary archive for Ubuntu $UBUNTU_VERSION"
           mkdir -p release
           cp ghostty/zig-out/bin/ghostty release/
           tar czf "ghostty-linux-x86_64-ubuntu${UBUNTU_VERSION}.tar.gz" -C release .
-          
+
           echo "Checking generated files:"
-          ls -la ghostty-linux-x86_64-ubuntu${UBUNTU_VERSION}.tar.gz
+          ls -la "ghostty-linux-x86_64-ubuntu${UBUNTU_VERSION}.tar.gz"
 
       - name: List files before upload
         run: |
@@ -229,13 +239,15 @@ jobs:
     needs: [check-tag, build-and-package]
     if: needs.check-tag.outputs.should_build == 'true'
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: write
+
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          
+
       - name: Debug artifact structure
         run: |
           echo "Full directory structure:"
@@ -244,7 +256,7 @@ jobs:
           find artifacts/ -name "*.deb"
           echo "Looking for TAR.GZ files:"
           find artifacts/ -name "*.tar.gz"
-          
+
       - name: Prepare files for release
         run: |
           mkdir -p release
@@ -252,9 +264,9 @@ jobs:
           find artifacts/ -name "*.tar.gz" -exec cp {} release/ \;
           echo "Files ready for release:"
           ls -la release/
-        
+
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/update_readme.yml
+++ b/.github/workflows/update_readme.yml
@@ -10,36 +10,40 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    
+
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Get latest release version
         id: get_version
         run: |
           LATEST_TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
-          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "latest_tag=$LATEST_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Update README
         run: |
           # Read the current README
           content=$(cat README.md)
-          
+
           # Update the version line with both the link text and URL
           # Matches the line "# Latest Version : [vX.Y.Z](https://github.com/MohamedElashri/build-ghostty/releases/tag/vX.Y.Z)"
-          new_content=$(echo "$content" | sed -E "s|# Latest Version : \[v[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/MohamedElashri/build-ghostty/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+\)|# Latest Version : [${{ steps.get_version.outputs.latest_tag }}](https://github.com/MohamedElashri/build-ghostty/releases/tag/${{ steps.get_version.outputs.latest_tag }})|g")
-          
+          new_content=$(echo "$content" | sed -E "s|# Latest Version : \[v[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/MohamedElashri/build-ghostty/releases/tag/v[0-9]+\.[0-9]+\.[0-9]+\)|# Latest Version : [${LATEST_TAG}](https://github.com/MohamedElashri/build-ghostty/releases/tag/${LATEST_TAG})|g")
+
           # Write the new content back to README
           echo "$new_content" > README.md
+        env:
+          LATEST_TAG: ${{ steps.get_version.outputs.latest_tag }}
 
       - name: Commit and push if changed
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          
+
           git diff
           git add README.md
-          git commit -m "docs: update version in README to ${{ steps.get_version.outputs.latest_tag }}" || exit 0
+          git commit -m "docs: update version in README to ${LATEST_TAG}" || exit 0
           git push
+        env:
+          LATEST_TAG: ${{ steps.get_version.outputs.latest_tag }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,116 @@
+---
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+# cspell:ignore autofix shellcheck shfmt yamlfmt gitleaks unattend scrollback actionlint zizmor github
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      # non-default
+      - id: check-case-conflict
+      - id: check-executables-have-shebangs
+        exclude: |
+          (?x)^(
+              .*\.ps1|
+              path/to/file\.py
+          )$
+      - id: check-json
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-xml
+      - id: detect-private-key
+      - id: mixed-line-ending
+#      - id: pretty-format-json
+#        args: ["--autofix"]
+#  - repo: https://github.com/google/yamlfmt
+#    rev: v0.14.0
+#    hooks:
+#      - id: yamlfmt
+#        args: ["-formatter", "include_document_start=true,scan_folded_as_literal=true"]
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        args: ["--color=always", "--external-sources"]
+        types: ["executable", "file", "shell", "text"]
+        exclude: |
+          (?x)^(
+              path/to/file\.py
+          )$
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.10.0-1
+    hooks:
+      - id: shfmt
+        args: ["--diff", "--indent", "2", "--binary-next-line", "--space-redirects", "--case-indent"]
+        types: ["executable", "file", "shell", "text"]
+        exclude: |
+          (?x)^(
+              path/to/file\.py
+          )$
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.4
+    hooks:
+      - id: actionlint
+  - repo: https://github.com/woodruffw/zizmor
+    rev: v0.5.0
+    hooks:
+      - id: zizmor
+        files: ^\.github/workflows/.*\.ya?ml$
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+        args: ["--no-banner"]
+#  - repo: https://github.com/amperser/proselint
+#    rev: 0.14.0
+#    hooks:
+#      - id: proselint
+#        types: ["asciidoc", "file", "non-executable", "plain-text", "text"]
+#  - repo: https://github.com/streetsidesoftware/cspell-cli
+#    rev: v8.16.0
+#    hooks:
+#      - id: cspell
+#        additional_dependencies:
+#          - "@cspell/dict-de-de"
+#          - "@cspell/dict-vim"
+#          - "@cspell/dict-win32"
+#        args:
+#          - "--locale"
+#          - "en,en-US,de-DE"
+#          - "--no-progress"
+#          - "--no-summary"
+#          # Include files and directories starting with '.' when matching
+#          # globs.
+#          - "--dot"
+#          # Show the surrounding text around an issue.
+#          - "--show-context"
+#          # Ignore files matching glob patterns found in .gitignore files.
+#          #- "--gitignore"
+#          # For easier adding of words to dictionaries.
+#          #- "--words-only"
+#          #- "--unique"
+#          # This might eventually be useful for some tricky issues.
+#          #- "--verbose"
+#          #- "--no-cache"
+#          #- "--cache-reset"
+#          # Not useful at all unless you are prepared to filter JSON output
+#          # longer than your scrollback buffer.
+#          #- "--debug"
+#        types: ["file", "text"]
+#        exclude: |
+#          (?x)^(
+#              \.gitignore|
+#              \.proselintrc\.json|
+#              .*\.cast|
+#              .*\.ini|
+#              .*\.json|
+#              .*\.ps1|
+#              .*\.svg|
+#              path/to/file\.py
+#          )$

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+# cspell:ignore precommit
+SHELL := /bin/bash
+
+.PHONY: all
+all: update-precommit
+
+.PHONY: update-precommit
+update-precommit:
+	pre-commit autoupdate
+
+.PHONY: pre-commit-run-all-files
+pre-commit-run-all-files:
+	for i in $(shell grep -e "- id:" ".pre-commit-config.yaml" | sed 's/ *- id: //g'); do \
+	  read -n1 -rp "Use $${i}? (y/N) "; \
+	  if [[ "$${REPLY}" == "y" ]]; then \
+	    echo -e "\n$${i}"; \
+	    pre-commit run $${i} --all-files; \
+	  else \
+	    echo -e "\nSkipped $${i}."; \
+	  fi; \
+	done


### PR DESCRIPTION
Remaining linter warnings:

```
Lint GitHub Actions workflow files.......................................Failed
- hook id: actionlint
- exit code: 1

.github/workflows/build.yml:55:27: property "get_tag" is not defined in object type {} [expression]
   |
55 |           INPUTS_TAG: ${{ steps.get_tag.outputs.tag }}
   |                           ^~~~~~~~~~~~~~~~~~~~~~~~~
```

This looks like a false alarm to me.

```
zizmor...................................................................Failed
- hook id: zizmor
- exit code: 13

🌈 completed build.yml
🌈 completed update_readme.yml
warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> .github/workflows/update_readme.yml:13:9
   |
13 |         - uses: actions/checkout@v4
   |  _________-
14 | |         with:
15 | |           fetch-depth: 0
   | |________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

1 finding: 0 unknown, 0 informational, 0 low, 1 medium, 0 high
```

I have not investigated further how to resolve this finding.

I can add the `.pre-commit-config.yaml` configuraton I used if you are interested.

Edit: https://github.com/lwbt/build-ghostty/blob/linters/.pre-commit-config.yaml